### PR TITLE
Added id output to gke_cluster module in base

### DIFF
--- a/modules/base/gke/gke_cluster/outputs.tf
+++ b/modules/base/gke/gke_cluster/outputs.tf
@@ -7,3 +7,7 @@ output "name"{
 output "location"{
     value = google_container_cluster.primary.*.location
 }
+
+output "id"{
+    value = google_container_cluster.primary.*.id
+}


### PR DESCRIPTION
Id output value was created for the gke_cluster module in modules/base/gke.