### PR TITLE
Created gke_autopilot dir and gke_autopilot.tf

### DIFF
--- a/gke_autopilot.tf
+++ b/gke_autopilot.tf
@@ -10,5 +10,4 @@ module "gke_autopilot_test"{
     # Inputs for google container cluster
     cluster_name                = "test-cluster"
     location                    = "us-west1"
-    enable_autopilot            = true
 }

--- a/gke_autopilot.tf
+++ b/gke_autopilot.tf
@@ -1,0 +1,14 @@
+# Module for GKE cluster with separate node pool
+
+module "gke_autopilot_test"{
+    source = "./modules/gke_autopilot"
+    
+    # Inputs for google service account
+    account_id                  = "gketest01"
+    display_name                = "GKE Test Account"
+
+    # Inputs for google container cluster
+    cluster_name                = "test-cluster"
+    location                    = "us-west1"
+    enable_autopilot            = true
+}

--- a/modules/base/gke/gke_cluster/main.tf
+++ b/modules/base/gke/gke_cluster/main.tf
@@ -3,7 +3,8 @@
 resource "google_container_cluster" "primary"{
     name                        = var.cluster_name
     location                    = var.location
-    
+    enable_autopilot            = var.enable_autopilot  
+
     remove_default_node_pool    = var.remove_default_node_pool
     initial_node_count          = var.initial_node_count
 }

--- a/modules/base/gke/gke_cluster/main.tf
+++ b/modules/base/gke/gke_cluster/main.tf
@@ -3,7 +3,6 @@
 resource "google_container_cluster" "primary"{
     name                        = var.cluster_name
     location                    = var.location
-    enable_autopilot            = var.enable_autopilot  
 
     remove_default_node_pool    = var.remove_default_node_pool
     initial_node_count          = var.initial_node_count

--- a/modules/base/gke/gke_cluster/variables.tf
+++ b/modules/base/gke/gke_cluster/variables.tf
@@ -8,11 +8,6 @@ variable "location"{
     description = "What region/zone is your cluster located in"
 }
 
-variable "enable_autopilot" {
-    description = "Use Autopilot mode clusters"
-    default = false
-}
-
 variable "initial_node_count"{
     description = "number of nodes in the default node pool"
     default = 1

--- a/modules/gke_autopilot/main.tf
+++ b/modules/gke_autopilot/main.tf
@@ -8,7 +8,7 @@ resource "google_service_account" "service_account"{
 resource "google_container_cluster" "autopilot"{
     name                        = var.cluster_name
     location                    = var.location
-    enable_autopilot            = var.enable_autopilot  
+    enable_autopilot            = true 
 }
 
 # GKE provisions and managaes node pools, 

--- a/modules/gke_autopilot/main.tf
+++ b/modules/gke_autopilot/main.tf
@@ -5,8 +5,13 @@ resource "google_service_account" "service_account"{
     display_name    = var.display_name
 }
 
+resource "google_container_cluster" "autopilot"{
+    name                        = var.cluster_name
+    location                    = var.location
+    enable_autopilot            = var.enable_autopilot  
+}
+
 module "create_autopilot_cluster"{
-    source = "../base/gke/gke_cluster"
 
     account_id                  = var.account_id
     display_name                = var.display_name
@@ -14,7 +19,6 @@ module "create_autopilot_cluster"{
     cluster_name                = var.cluster_name
     location                    = var.location
     enable_autopilot            = var.enable_autopilot 
-    remove_default_node_pool    = var.remove_default_node_pool
 }
 
 # GKE provisions and managaes node pools, 

--- a/modules/gke_autopilot/main.tf
+++ b/modules/gke_autopilot/main.tf
@@ -14,7 +14,7 @@ module "create_autopilot_cluster"{
     cluster_name                = var.cluster_name
     location                    = var.location
     enable_autopilot            = var.enable_autopilot 
-
+    remove_default_node_pool    = var.remove_default_node_pool
 }
 
 # GKE provisions and managaes node pools, 

--- a/modules/gke_autopilot/main.tf
+++ b/modules/gke_autopilot/main.tf
@@ -12,7 +12,7 @@ resource "google_container_cluster" "autopilot"{
 }
 
 module "create_autopilot_cluster"{
-    source                      = "./"
+    source                      = "./gke_autopilot"
     
     account_id                  = var.account_id
     display_name                = var.display_name

--- a/modules/gke_autopilot/main.tf
+++ b/modules/gke_autopilot/main.tf
@@ -12,7 +12,8 @@ resource "google_container_cluster" "autopilot"{
 }
 
 module "create_autopilot_cluster"{
-
+    source                      = "./"
+    
     account_id                  = var.account_id
     display_name                = var.display_name
 

--- a/modules/gke_autopilot/main.tf
+++ b/modules/gke_autopilot/main.tf
@@ -1,0 +1,21 @@
+# Module for GKE Autopilot Cluster
+
+resource "google_service_account" "service_account"{
+    account_id      = var.account_id
+    display_name    = var.display_name
+}
+
+module "create_autopilot_cluster"{
+    source = "../base/gke/gke_cluster"
+
+    account_id                  = var.account_id
+    display_name                = var.display_name
+
+    cluster_name                = var.cluster_name
+    location                    = var.location
+    enable_autopilot            = var.enable_autopilot 
+
+}
+
+# GKE provisions and managaes node pools, 
+# User cannot configure node pool settings in autopilot mode

--- a/modules/gke_autopilot/main.tf
+++ b/modules/gke_autopilot/main.tf
@@ -11,16 +11,5 @@ resource "google_container_cluster" "autopilot"{
     enable_autopilot            = var.enable_autopilot  
 }
 
-module "create_autopilot_cluster"{
-    source                      = "./gke_autopilot"
-    
-    account_id                  = var.account_id
-    display_name                = var.display_name
-
-    cluster_name                = var.cluster_name
-    location                    = var.location
-    enable_autopilot            = var.enable_autopilot 
-}
-
 # GKE provisions and managaes node pools, 
 # User cannot configure node pool settings in autopilot mode

--- a/modules/gke_autopilot/variables.tf
+++ b/modules/gke_autopilot/variables.tf
@@ -14,6 +14,11 @@ variable "enable_autopilot" {
     default = true
 }
 
+variable "remove_default_node_pool"{
+    description = "Are you using a separate node pool"
+    default = false
+}
+
 variable "account_id" {
     description = "service account identifier"
 }

--- a/modules/gke_autopilot/variables.tf
+++ b/modules/gke_autopilot/variables.tf
@@ -1,7 +1,8 @@
-# Vairables for Google Container Cluster Resource
+# Variables for GKE Autopilot Cluster with default node pool
 
 variable "cluster_name"{
     description = "Name for your cluster"
+    type = string
 }
 
 variable "location"{
@@ -10,16 +11,6 @@ variable "location"{
 
 variable "enable_autopilot" {
     description = "Use Autopilot mode clusters"
-    default = false
-}
-
-variable "initial_node_count"{
-    description = "number of nodes in the default node pool"
-    default = 1
-}
-
-variable "remove_default_node_pool"{
-    description = "Are you using a separate node pool"
     default = true
 }
 

--- a/modules/gke_autopilot/variables.tf
+++ b/modules/gke_autopilot/variables.tf
@@ -9,11 +9,6 @@ variable "location"{
     description = "What region/zone is your cluster located in"
 }
 
-variable "enable_autopilot" {
-    description = "Use Autopilot mode clusters"
-    default = true
-}
-
 variable "account_id" {
     description = "service account identifier"
 }

--- a/modules/gke_autopilot/variables.tf
+++ b/modules/gke_autopilot/variables.tf
@@ -14,11 +14,6 @@ variable "enable_autopilot" {
     default = true
 }
 
-variable "remove_default_node_pool"{
-    description = "Are you using a separate node pool"
-    default = false
-}
-
 variable "account_id" {
     description = "service account identifier"
 }


### PR DESCRIPTION
Created separate directory for gke_autopilot module with its own set of variables.

Created gke_autopilot.tf file that calls the gke_autopilot module to create autopilot clusters.

The gke_autopilot module calls the base module in modules/base/gke/gke_cluster but doesn't call the node_pool resource because that is provisioned and managed my gke when using autopilot.