### PR TITLE
Added variables and code blocks to enable cluster autoscaling

### DIFF
--- a/gke.tf
+++ b/gke.tf
@@ -12,6 +12,10 @@ module "gke_cluster_test"{
     location                    = "us-west1"
     remove_default_node_pool    = true
     initial_node_count          = 1
+    cluster_autoscaling_enabled = true
+    minimum_cpu_vcores          = 6
+    maximum_cpu_vcores          = 12
+    maximum_memory              = 64
     
     # Inputs for separate node pool
     node_pool_name              = "my-test-node-pool"

--- a/modules/base/gke/gke_cluster/main.tf
+++ b/modules/base/gke/gke_cluster/main.tf
@@ -6,4 +6,17 @@ resource "google_container_cluster" "primary"{
 
     remove_default_node_pool    = var.remove_default_node_pool
     initial_node_count          = var.initial_node_count
+    cluster_autoscaling {
+        enabled                 = var.cluster_autoscaling_enabled
+        resource_limits {
+            resource_type       = "cpu"
+            minimum             = var.minimum_cpu_vcores
+            maximum             = var.maximum_cpu_vcores
+        }
+
+        resource_limits {
+            resource_type       = "memory"
+            maximum             = var.maximum_memory
+        }
+    }
 }

--- a/modules/base/gke/gke_cluster/variables.tf
+++ b/modules/base/gke/gke_cluster/variables.tf
@@ -18,6 +18,26 @@ variable "remove_default_node_pool"{
     default = true
 }
 
+variable "cluster_autoscaling_enabled" {
+    description = "Automatically adjust the size of the cluster + automatically create/delete node pools"
+    default = false
+}
+
+variable "minimum_cpu_vcores" {
+    description = "minimum number of virtual cpus in your cluster"
+    default = 2
+}
+
+variable "maximum_cpu_vcores" {
+    description = "maximum number of virtual cpus in your cluster"
+    default = 10
+}
+
+variable "maximum_memory" {
+    description = "maximum virtual memory provisioned for your cluster"
+    default = 64
+}
+
 variable "account_id" {
     description = "service account identifier"
 }

--- a/modules/gke/main.tf
+++ b/modules/gke/main.tf
@@ -16,7 +16,10 @@ module "create_gke_cluster"{
 
     remove_default_node_pool    = var.remove_default_node_pool
     initial_node_count          = var.initial_node_count
-
+    cluster_autoscaling_enabled = var.cluster_autoscaling_enabled
+    minimum_cpu_vcores          = var.minimum_cpu_vcores
+    maximum_cpu_vcores          = var.maximum_cpu_vcores
+    maximum_memory              = var.maximum_memory
 }
 
 module "create_node_pool"{

--- a/modules/gke/variables.tf
+++ b/modules/gke/variables.tf
@@ -19,6 +19,26 @@ variable "remove_default_node_pool"{
     default = true
 }
 
+variable "cluster_autoscaling_enabled" {
+    description = "Automatically adjust the size of the cluster + automatically create/delete node pools"
+    default = false
+}
+
+variable "minimum_cpu_vcores" {
+    description = "minimum number of virtual cpus in your cluster"
+    default = 2
+}
+
+variable "maximum_cpu_vcores" {
+    description = "maximum number of virtual cpus in your cluster"
+    default = 10
+}
+
+variable "maximum_memory" {
+    description = "maximum virtual memory provisioned for your cluster"
+    default = 64
+}
+
 variable "node_pool_name" {
     description = "Name your node pool"
 }


### PR DESCRIPTION
Added "cluster_autosclaing" code block to base/gke/gke_cluster/main.tf that is required to enable cluster autoscaling.

Added necessary variables to fill in cluster_autoscaling code block.

gke.tf file has not been edited yet.